### PR TITLE
http_build_query fix for buggy PHP versions

### DIFF
--- a/dist/admin/tools.php
+++ b/dist/admin/tools.php
@@ -57,7 +57,7 @@
  		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
  		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
  		curl_setopt($ch, CURLOPT_VERBOSE, true);
- 		curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
+ 		curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params, '', '&'));
  		$response = curl_exec ($ch);
  		$authObj=json_decode($response);
     $msg=curl_error($ch);

--- a/dist/authorize.php
+++ b/dist/authorize.php
@@ -78,7 +78,7 @@
       "scope" =>          "https://picasaweb.google.com/data profile email"
     );
 
-    $request_to = OAUTH2_AUTH_URL . '?' . http_build_query($params);
+    $request_to = OAUTH2_AUTH_URL . '?' . http_build_query($params, '', '&');
 
     header("Location: " . $request_to);     // display authorization form
   }
@@ -103,7 +103,7 @@
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 		curl_setopt($ch, CURLOPT_VERBOSE, true);
-    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params, '', '&'));
     $response = curl_exec($ch);
     $authObj = json_decode($response);
     $info = curl_getinfo($ch);

--- a/dist/nanogp.php
+++ b/dist/nanogp.php
@@ -89,7 +89,7 @@
     $request['access_token']=$atoken;
     
     $ch = curl_init();
-    $url = $url . '?' . http_build_query($request);
+    $url = $url . '?' . http_build_query($request, '', '&');
     curl_setopt($ch, CURLOPT_URL, $url );
     curl_setopt($ch, CURLOPT_HEADER, false);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
In PHP 5.3.1 `http_build_query` DOES escape the '&' ampersand character that joins the parameters. Example: user_id=1&amp;setting_id=2.
It makes the script not running correctly.

This PR provides a fix for that to make script running on every version of PHP > 5.2 as specified.
